### PR TITLE
Generic metadata support and embed improvements

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -30,13 +30,13 @@
 	"observability": {
 		"logs": {
 			"enabled": true,
-			"head_sampling_rate": 0.1,
+			"head_sampling_rate": 1,
 			"invocation_logs": false,
 			"persist": true
 		},
 		"traces": {
 			"enabled": true,
-			"head_sampling_rate": 0.1,
+			"head_sampling_rate": 1,
 			"persist": true
 		}
 	}


### PR DESCRIPTION
## Summary

This PR refactors the codebase to support multiple providers and adds several improvements:

### Changes

1. **Generic Metadata Interface**: Renamed `FacebookMetadata` to `LinkMetadata` to support future providers beyond Facebook. The embed function was renamed from `createFacebookEmbed` to `createRichPreviewEmbed` with optional provider configuration.

2. **Reply Functionality**: Changed embeds to be posted as replies to the original message instead of standalone messages, providing better context and threading.

3. **Facebook Story URL Handling**: Added URL normalization and handling for Facebook `story.php` URLs to ensure proper metadata extraction.

4. **Error Logging Improvements**: Added comprehensive error logging throughout the codebase with structured context tags to catch silent failures and improve debugging.

5. **Article Title and URL Extraction**: Added extraction of article titles from `title_with_entities` JSON patterns with proper Unicode decoding, and extraction of ExternalWebLink URLs from attachment patterns for posts linking to articles.

6. **Embed Structure Updates**: Updated embed structure for article posts - when an article URL is present, the article title is used as the embed title (linked to the article), with the domain shown in the footer.

7. **Image URL Extraction**: Fixed image URL extraction to preserve aspect ratio by extracting the original image URL from Facebook CDN URLs instead of using the CDN URL directly (which serves square images to Discord).

Closes #1